### PR TITLE
Annotation for strict mode

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "made-js",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "authors": [
     "Arne Simon [arne.simon@slice-dice.de]",
     "Max Fielker [max.fielker@slice-dice.de]"

--- a/dist/made.js
+++ b/dist/made.js
@@ -2,7 +2,9 @@
  * @author Arne Simon [arne.simon@slice-dice.de]
  * @author Max Fielker [max.fielker@slice.dice.de]
  */
-var madejs = angular.module('made-js', ['uuid4', 'ngCookies'], function($compileProvider) {
+var madejs = angular.module('made-js', ['uuid4', 'ngCookies']);
+
+madejs.config(['$compileProvider', function($compileProvider) {
     // configure new 'made-compile' directive by passing a directive
     // factory function. The factory function injects the '$compile'
     $compileProvider.directive('madeCompile', function($compile) {
@@ -27,7 +29,7 @@ var madejs = angular.module('made-js', ['uuid4', 'ngCookies'], function($compile
             );
         };
     });
-});
+}]);
 
 var LOGGING = true;
 

--- a/src/madejs.js
+++ b/src/madejs.js
@@ -2,7 +2,9 @@
  * @author Arne Simon [arne.simon@slice-dice.de]
  * @author Max Fielker [max.fielker@slice.dice.de]
  */
-var madejs = angular.module('made-js', ['uuid4', 'ngCookies'], function($compileProvider) {
+var madejs = angular.module('made-js', ['uuid4', 'ngCookies']);
+
+madejs.config(['$compileProvider', function($compileProvider) {
     // configure new 'made-compile' directive by passing a directive
     // factory function. The factory function injects the '$compile'
     $compileProvider.directive('madeCompile', function($compile) {
@@ -27,7 +29,7 @@ var madejs = angular.module('made-js', ['uuid4', 'ngCookies'], function($compile
             );
         };
     });
-});
+}]);
 
 var LOGGING = true;
 


### PR DESCRIPTION
We're using the plugin with webpack, which is running is strict mode. In strict mode all the providers has to be annotated. Here's a fix for the issue.

[Here is the original error](https://docs.angularjs.org/error/$injector/strictdi), including the current version of made.js:
