### PR TITLE
Broadcast on rootscope when connection changes

### DIFF
--- a/src/made.js
+++ b/src/made.js
@@ -37,14 +37,17 @@ class Made {
     }
 
     this.wss.onopen = function () {
+      $rootScope.$broadcast('made-connection-open');
       console.log( 'socket open!' );
     };
 
     this.wss.onerror = function ( errorEvent ) {
+      $rootScope.$broadcast('made-connection-error');
       console.log( 'socket error, event:', errorEvent );
     };
 
     this.wss.onclose = function ( closeEvent ) {
+      $rootScope.$broadcast('made-connection-closed');
       console.log( 'socket close, event:', closeEvent );
       setTimeout( this.setupSocket, this.reconnectTimeout );
 


### PR DESCRIPTION
Broadcast when connection state changes. This is temporary until the new rewrite is landed. 
